### PR TITLE
fix(tag-image): build multi-arch (amd64+arm64) images in the release tag workflow

### DIFF
--- a/.github/workflows/update-image-tag.yml
+++ b/.github/workflows/update-image-tag.yml
@@ -9,6 +9,10 @@ on:
       registry:
         required: true
         type: string
+      platforms:
+        required: false
+        type: string
+        default: linux/amd64,linux/arm64
 
 permissions:
   contents: write
@@ -38,6 +42,9 @@ jobs:
           registry: ${{ inputs.registry }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.7.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,4 +52,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: ${{ inputs.platforms }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Problem
Projects using the `tag-image` reusable workflow (`update-image-tag.yml`) only ever get an `amd64` image published on tag, even when the Go binary itself is cross-compiled for `arm64` in the same release (see e.g. `envoy-proxy-crowdsec-bouncer`'s `.goreleaser.yml` `builds.goarch: [amd64, arm64]`).

Root cause: `docker/build-push-action` builds for the runner's native architecture only when no `platforms` input is passed, and GitHub-hosted runners are `amd64`. No QEMU setup either, so even passing `platforms` wouldn't have worked without it.

Concretely, this broke deploying `ghcr.io/kdwils/envoy-proxy-bouncer:v0.6.2` on an arm64 Kubernetes cluster:
```
no image found in image index for architecture "arm64", variant "v8", OS "linux"
```

## Fix
Bring `update-image-tag.yml` in line with the pattern `build-image.yml` and `build-push-sign.yml` already use in this repo:
- Add `docker/setup-qemu-action@v3.7.0` (same version already pinned elsewhere in this repo).
- Add a `platforms` workflow_call input, defaulting to `linux/amd64,linux/arm64` - matching `build-image.yml`'s own default exactly, so this is additive/backward-compatible for every existing caller, not a new convention.
- Pass `platforms: ${{ inputs.platforms }}` to the `build-push-action` step.

## Verification
YAML-validated; no other workflow files touched. Diff is 8 lines.